### PR TITLE
Add example for using the uProtocol Target Provider

### DIFF
--- a/hpc_variant/samples/uprotocol_provider/README.md
+++ b/hpc_variant/samples/uprotocol_provider/README.md
@@ -1,0 +1,63 @@
+## Prerequisites
+
+* [Rust toolchain installed](https://rustup.rs/) on your local machine
+* Podman installed as described in the [Ankaios README](../../README.md)
+* [ECU Updater example application](https://github.com/eclipse-uprotocol/symphony-target-example-rust) running on your machine
+
+## Steps
+
+1. Make sure that the Symphony agent Ankaios workload is not running
+   ```bash
+   ank get workloads
+   ```
+   If necessary, stop the _symphony_ workload
+   ```bash
+   ank delete workload symphony
+   ```
+2. Clone the Symphony repository
+   ```bash
+   git clone https://github.com/boschglobal/symphony.git
+   ```
+   and switch to the `add_uprotocol_target_provider` branch
+   ```bash
+   cd symphony
+   git checkout add_uprotocol_target_provider
+   ```
+3. Build the Rust based target providers
+   ```bash
+   cd api/pkg/apis/v1alpha1/providers/target/rust
+   cargo build --release
+   ```
+4. Create a Podman volume for holding the uProtocol Target Provider library:
+   ```bash
+   sudo podman volume create hackathon-extensions
+   HACKATHON_EXTENSIONS_VOLUME_PATH=$(sudo podman volume inspect --format "{{ .Mountpoint }}" hackathon-extensions)
+   sudo cp target/release/libuprotocol.so "$HACKATHON_EXTENSIONS_VOLUME_PATH"
+   ```
+   The Symphony agent is configured to look inside of this volume for additional target providers. So when you create a Target that refers to the uProtocol Target Provider using the Symphony API, then the Symphony agent will load the library from this volume and let it handle the request to create the target.
+5. Apply the Ankaios state to start the Ankaios Dashboard and the update trigger application.
+   ```bash
+   cd $REPO_ROOT/hpc_variant/ankaios/samples/uprotocol_provider
+   ank apply ./state.yaml
+   ```
+6. Open the [Update Trigger Application](http://localhost:5500) and click the button
+7. Verify that the Symphony agent workload has started successfully
+   ```bash
+   ank get workloads
+   WORKLOAD NAME       AGENT     RUNTIME   EXECUTION STATE   ADDITIONAL INFO
+   Ankaios_Dashboard   agent_A   podman    Running(Ok)                      
+   symphony            agent_A   podman    Running(Ok)                      
+   update_trigger      agent_A   podman    Running(Ok)  
+   ```
+8. Deploy some ECU firmware by means of the ECU Updater application
+   ```bash
+   ./test_uprotocol_provider.sh
+   ```
+   This should result in the ECU Updater application printing some info to the console that looks like
+   ```bash
+   [2025-10-01T08:08:14Z INFO  ecu_updater] processing GET request [from: up://symphony/DA00/1/0]
+   [2025-10-01T08:08:14Z INFO  ecu_updater] processing GET request [from: up://symphony/DA00/1/0]
+   [2025-10-01T08:08:14Z INFO  ecu_updater] processing request [method: up://ecu-updater.app/A100/1/2, from: up://symphony/DA00/1/0]
+   [2025-10-01T08:08:14Z INFO  ecu_updater::deployment_state] installing firmware [name: Engine Controller, FW Image: "https://acme.io/fw/engine-control-1.45.img"]
+   [2025-10-01T08:08:14Z INFO  ecu_updater::deployment_state] installing firmware [name: Telematics Unit, FW Image: "https://non-existent.io/fw/telematics-unit-2.0.img"]
+   ```

--- a/hpc_variant/samples/uprotocol_provider/README.md
+++ b/hpc_variant/samples/uprotocol_provider/README.md
@@ -2,7 +2,10 @@
 
 * [Rust toolchain installed](https://rustup.rs/) on your local machine
 * Podman installed as described in the [Ankaios README](../../README.md)
-* [ECU Updater example application](https://github.com/eclipse-uprotocol/symphony-target-example-rust) running on your machine
+* [ECU Updater example application](https://github.com/eclipse-uprotocol/symphony-target-example-rust) running on your machine with a minimum log level of `info`:
+  ```bash
+  RUST_LOG=info ./target/debug/ecu-updater mqtt5
+  ```
 
 ## Steps
 

--- a/hpc_variant/samples/uprotocol_provider/state.yaml
+++ b/hpc_variant/samples/uprotocol_provider/state.yaml
@@ -32,7 +32,7 @@ workloads:
         data: "{{symphony_config}}"
     runtimeConfig: |
       image: ghcr.io/eclipse-symphony/symphony-api:0.48-proxy.41
-      commandOptions: ["-e","CONFIG=/symphony-agent.json", "--net=host"]
+      commandOptions: ["-e", "LOG_LEVEL=Info", "-e","CONFIG=/symphony-agent.json", "-e", "RUST_LOG=INFO,uprotocol=INFO", "--net=host", "-v", "hackathon-extensions:/hackathon-extensions"]
   Ankaios_Dashboard:
     runtime: podman
     agent: agent_A
@@ -96,7 +96,7 @@ configs:
                   "providers.secret": "mock-secret",
                   "providers.keylock": "mem-keylock",
                   "isTarget": "true",
-                  "targetNames": "ankaios-target",
+                  "targetNames": "ankaios-target,ecu-updater-target",
                   "poll.enabled": "true"
                 },
                 "providers": {
@@ -124,6 +124,17 @@ configs:
                       "name": "ankaios-type",
                       "libFile": "/extensions/libankaios.so",
                       "libHash": "23b67af66adc4830547528da66bb307c72bccef9db5de386b33cf3e1dc9ea483"
+                    }
+                  },
+                  "ecu-updater":{
+                    "type": "providers.target.rust",
+                    "config": {
+                      "name": "ecu-updater-type",
+                      "libFile": "/hackathon-extensions/libuprotocol.so",
+                      "libHash": "any",
+                      "localEntity": "up://symphony/DA00/1/0",
+                      "getMethodUri": "up://ecu-updater.app/A100/1/1",
+                      "brokerAddress": "mqtt://host.containers.internal:1883"
                     }
                   }
                 }

--- a/hpc_variant/samples/uprotocol_provider/target.json
+++ b/hpc_variant/samples/uprotocol_provider/target.json
@@ -1,0 +1,50 @@
+{
+    "metadata": {
+        "name": "ecu-updater-target"
+    },
+    "spec": {
+        "displayName": "Vehicle_ECUs",
+        "forceRedeploy": true,
+        "components": [
+            {
+                "name": "Engine Controller",
+                "metadata": {
+                    "manufacturer": "ACME Inc.",
+                    "model": "EC-14"
+                },
+                "type": "ecu-updater",
+                "properties": {
+                    "fw-image": "https://acme.io/fw/engine-control-1.45.img"
+                }
+            },
+            {
+                "name": "Telematics Unit",
+                "type": "ecu-updater",
+                "properties": {
+                    "fw-image": "https://non-existent.io/fw/telematics-unit-2.0.img"
+                },
+                "parameters": {
+                    "back-end-url": "https://non-existent.io/telematics"
+                }
+            }
+        ],
+        "topologies": [
+            {
+                "bindings": [
+                    {
+                        "role": "ecu-updater",
+                        "provider": "providers.target.mqtt",
+                        "config": {
+                            "name": "proxy",
+                            "brokerAddress": "tcp://127.0.0.1:1883",
+                            "clientID": "symphony",
+                            "requestTopic": "coa-request",
+                            "responseTopic": "coa-response",
+                            "timeoutSeconds": "30"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/hpc_variant/samples/uprotocol_provider/test_uprotocol_provider.sh
+++ b/hpc_variant/samples/uprotocol_provider/test_uprotocol_provider.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export SYMPHONY_API_URL=http://localhost:8082/v1alpha2/
+
+TOKEN=$(curl -X POST -H "Content-Type: application/json" -d '{"username":"admin","password":""}' "${SYMPHONY_API_URL}users/auth" | jq -r '.accessToken')
+
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" --data @./target.json "${SYMPHONY_API_URL}targets/registry/ecu-updater-target"
+
+# Prompt user to press Enter to continue after the target has been registered
+read -p "Target registered. Press Enter to remove..."
+
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "${SYMPHONY_API_URL}targets/registry/ecu-updater-target"


### PR DESCRIPTION
Added an example that shows how to use Symphony's uProtocol Target Provider to deploy firmware to ECUs by means of a uProtocol Application.